### PR TITLE
BUG: finish update to VTK6 by using SetInputData

### DIFF
--- a/Py/SlicerReportingModuleWidgetHelper.py
+++ b/Py/SlicerReportingModuleWidgetHelper.py
@@ -512,7 +512,7 @@ class SlicerReportingModuleWidgetHelper( object ):
     return node
 
   @staticmethod
-  def initializeNewLabel(newLabel, sourceVolume):    
+  def initializeNewLabel(newLabel, sourceVolume):
     displayNode = slicer.mrmlScene.AddNode(slicer.vtkMRMLLabelMapVolumeDisplayNode())
 
     threshold = vtk.vtkImageThreshold()
@@ -521,7 +521,10 @@ class SlicerReportingModuleWidgetHelper( object ):
     threshold.SetInValue(0)
     threshold.SetOutValue(0)
     threshold.SetOutputScalarTypeToUnsignedShort()
-    threshold.SetInput(sourceVolume.GetImageData())
+    if vtk.vtkVersion().GetVTKMajorVersion() < 6:
+      threshold.SetInput(sourceVolume.GetImageData())
+    else:
+      threshold.SetInputData(sourceVolume.GetImageData())
     threshold.Update()
 
     labelImage = vtk.vtkImageData()

--- a/Util/LabelToDICOMSEGConverterScript.py
+++ b/Util/LabelToDICOMSEGConverterScript.py
@@ -102,7 +102,10 @@ def DoIt(inputDir, labelFile, outputDir, forceLabel):
       print('Forcing label to '+str(forceLabel))
       labelImage = labelVolume.GetImageData()
       thresh = vtk.vtkImageThreshold()
-      thresh.SetInput(labelImage)
+      if vtk.vtkVersion().GetVTKMajorVersion() < 6:
+        thresh.SetInput(labelImage)
+      else:
+        thresh.SetInputData(labelImage)
       thresh.ThresholdBetween(1, labelImage.GetScalarRange()[1])
       thresh.SetInValue(int(forceLabel))
       thresh.SetOutValue(0)


### PR DESCRIPTION
A few missing instances were spotted where python methods weren't
update to check for the current VTK version and use SetInput if
used with VTK version less than 6 or SetInputData otherwise.
Removed some unnecessary spaces.
