### PR TITLE
BUG: Fix the loaded check for seg2nrrd

### DIFF
--- a/Py/DICOMSegmentationPlugin.py
+++ b/Py/DICOMSegmentationPlugin.py
@@ -134,8 +134,10 @@ class DICOMSegmentationPluginClass(DICOMPlugin):
       "inputSEGFileName": segFileName,
       "outputDirName": outputDir,
       }
-    seg2nrrd = slicer.modules.seg2nrrd
-    if seg2nrrd == None:
+    seg2nrrd = None
+    try:
+      seg2nrrd = slicer.modules.seg2nrrd
+    except AttributeError:
       print 'Unable to find CLI module SEG2NRRD, unable to load DICOM Segmentation object'
       return False
     cliNode = None


### PR DESCRIPTION
Enclose trying to access the seg2nrrd module in a try block,
otherwise the loading process will hang if the CLI module wasn't
loaded correctly.